### PR TITLE
Fix/jwt 3816 fix build

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,44 +1,21 @@
 <settings>
     <servers>
         <server>
-            <id>nexus</id>
-            <username>${REPOSITORY_USERID}</username>
-            <password>${REPOSITORY_CREDENTIALS}</password>
-        </server>
-        <server>
             <id>maven2.releases.levigo.de</id>
             <username>${REPOSITORY_RELEASE_USERID}</username>
             <password>${REPOSITORY_RELEASE_CREDENTIALS}</password>
         </server>
-        <server>
-            <id>${REGISTRY_URL}</id>
-            <username>${REPOSITORY_USERID}</username>
-            <password>${REPOSITORY_CREDENTIALS}</password>
-        </server>
     </servers>
-    <pluginGroups>
-        <pluginGroup>org.sonarsource.scanner.maven</pluginGroup>
-    </pluginGroups>
+
     <profiles>
-        <profile>
-            <id>sonar</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <sonar.host.url>${SONAR_HOST_URL}</sonar.host.url>
-                <sonar.login>${SONAR_LOGIN}</sonar.login>
-            </properties>
-        </profile>
-        <!--
-         Downloading all maven artifacts from a mirror some 6000 miles away does not seem reasonable.
-         Therefore we download only the private artifacts from Nexus3 and all publicly available artifacts from maven-central.
-         -->
         <profile>
             <id>central-nexus</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <properties>
+                <altDeploymentRepository>maven2.releases.levigo.de::default::${REPOSITORY_URL}</altDeploymentRepository>
+            </properties>
             <repositories>
                 <repository>
                     <id>maven-central</id>
@@ -51,7 +28,7 @@
                     </releases>
                 </repository>
                 <repository>
-                    <id>nexus</id>
+                    <id>maven2.releases.levigo.de</id>
                     <url>${REPOSITORY_URL}</url>
                     <releases>
                         <enabled>true</enabled>
@@ -73,7 +50,7 @@
                     </releases>
                 </pluginRepository>
                 <pluginRepository>
-                    <id>nexus</id>
+                    <id>maven2.releases.levigo.de</id>
                     <url>${REPOSITORY_URL}</url>
                     <releases>
                         <enabled>true</enabled>

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -35,31 +35,18 @@ jobs:
 
       ## Configure JDK
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 8
-
-      ## Enable Caching
-      # Reduce cache size by excluding artifacts with the project.groupId
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
 
       ## Configure maven settings
       - name: Prepare maven settings
         env:
-          REGISTRY_URL: 'artifacts.jadice.com'
-          REPOSITORY_URL: ${{ secrets.LEVIGO_NEXUS_REPO_ALL }}
-          REPOSITORY_USERID: ${{ secrets.LEVIGO_NEXUS_USERNAME }}
-          REPOSITORY_CREDENTIALS: ${{ secrets.LEVIGO_NEXUS_PASSWORD }}
-          REPOSITORY_RELEASE_USERID: ${{ secrets.NEXUS2_USERNAME }}
-          REPOSITORY_RELEASE_CREDENTIALS: ${{ secrets.NEXUS2_PASSWORD }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          REPOSITORY_URL: ${{ secrets.NEXUS2_REPO_RELEASES }}
+          REPOSITORY_RELEASE_USERID: ${{ secrets.PUB_NEXUS2_USERNAME_RW }}
+          REPOSITORY_RELEASE_CREDENTIALS: ${{ secrets.PUB_NEXUS2_PASSWORD_RW }}
         run: |
           mkdir -p ~/.m2
           envsubst < ./.github/settings.xml > ~/.m2/settings.xml
@@ -93,7 +80,6 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          #don't use the GITHUB_TOKEN https://github:community/t/actions-not-triggered-on-release/17944/12:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.semanticversion.outputs.new_tag }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,6 @@ on:
     branches-ignore:
       - 'master'
     paths-ignore:
-      #   !! Attention!! removing the following line may produce an endless loop on the build system!!
       - '**/README.md'
 
 jobs:
@@ -22,34 +21,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      ## Enable Caching
-      # Reduce cache size by excluding artifacts with the project.groupId
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-
       ## Configure JDK
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
 
       ## Configure maven settings
       - name: Prepare maven settings
         env:
-          REGISTRY_URL: 'artifacts.jadice.com'
-          REPOSITORY_URL: ${{ secrets.LEVIGO_NEXUS_REPO_ALL }}
-          REPOSITORY_USERID: ${{ secrets.LEVIGO_NEXUS_USERNAME }}
-          REPOSITORY_CREDENTIALS: ${{ secrets.LEVIGO_NEXUS_PASSWORD }}
-          REPOSITORY_RELEASE_USERID: ${{ secrets.NEXUS2_USERNAME }}
-          REPOSITORY_RELEASE_CREDENTIALS: ${{ secrets.NEXUS2_PASSWORD }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          REPOSITORY_URL: ${{ secrets.NEXUS2_REPO_RELEASES }}
+          REPOSITORY_RELEASE_USERID: ${{ secrets.PUB_NEXUS2_USERNAME }}
+          REPOSITORY_RELEASE_CREDENTIALS: ${{ secrets.PUB_NEXUS2_PASSWORD}}
         run: |
           mkdir -p ~/.m2
           envsubst < ./.github/settings.xml > ~/.m2/settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,13 @@
 
     <organization>
         <name>sejda.com</name>
-        <url>http://www.sejda.com</url>
+        <url>https://www.sejda.com</url>
     </organization>
 
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
             <comments>ASLv2</comments>
         </license>
@@ -75,7 +75,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -88,6 +88,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -105,7 +106,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.9.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -114,7 +115,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.2</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -126,7 +127,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -139,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.0.0-M5</version>
             </plugin>
         </plugins>
     </build>
@@ -148,7 +149,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The cause for the original build failure was a change in the privileges of the secrets. They changed from read-write to read-only. 
Now we're using the new read-write secrets ( __RW_ )